### PR TITLE
Use new tre-event-lib package

### DIFF
--- a/tre-vb-bag-validation/requirements.txt
+++ b/tre-vb-bag-validation/requirements.txt
@@ -1,4 +1,4 @@
 requests~=2.28.1
 jsonschema~=4.15.0
 s3lib~=0.0.8
-trelib~=0.0.4
+tre-event-lib~=0.0.1


### PR DESCRIPTION
Use new version of tre-event-lib library when building ECR image.